### PR TITLE
Add per-period room numbers to student schedules

### DIFF
--- a/models/school.py
+++ b/models/school.py
@@ -99,7 +99,12 @@ class School:
 
 
 class StudentSchedule:
-    """Link students to schools and track their class schedules."""
+    """Link students to schools and track their class schedules.
+
+    The ``classes`` attribute stores a JSON object mapping period numbers to
+    dictionaries with ``name`` and ``room`` keys.  Older records may only have a
+    string class name; the application handles both formats.
+    """
     def __init__(self, id=None, student_id=None, school_id=None, lunch_type='A',
                  classes=None, created_at=None):
         self.id = id

--- a/routes/students.py
+++ b/routes/students.py
@@ -118,8 +118,12 @@ def student_schedule(student_id):
         classes = {}
         for period in range(1,9):
             class_name = request.form.get(f'period_{period}', '').strip()
-            if class_name:
-                classes[str(period)] = class_name
+            room_number = request.form.get(f'room_{period}', '').strip()
+            if class_name or room_number:
+                classes[str(period)] = {
+                    'name': class_name,
+                    'room': room_number
+                }
         schedule.classes = classes
         schedule.save(db)
         return redirect(url_for('students.student_detail', student_id=student_id))

--- a/templates/school_detail.html
+++ b/templates/school_detail.html
@@ -136,16 +136,21 @@
         <div class="grid grid-2" style="gap: 0.5rem;">
             {% for period in schedule.periods %}
                 {% if not period.lunch_type or period.lunch_type == student.lunch_type %}
-                    {% set class_name = student.classes.get(period.number|string, '') %}
-                    {% if class_name or period.get('is_lunch') %}
+                    {% set class_info = student.classes.get(period.number|string, '') %}
+                    {% if class_info or period.get('is_lunch') %}
                     <div style="
-                        padding: 0.5rem; 
+                        padding: 0.5rem;
                         font-size: 0.9rem;
                         border-radius: 3px;
-                        background: {% if period.get('is_lunch') %}#e8f5e8{% elif period.get('is_extension') and class_name %}#fff3cd{% elif class_name %}#e7f3ff{% else %}#f8f9fa{% endif %};
+                        background: {% if period.get('is_lunch') %}#e8f5e8{% elif period.get('is_extension') and class_info %}#fff3cd{% elif class_info %}#e7f3ff{% else %}#f8f9fa{% endif %};
                     ">
-                        <strong>P{{ period.number }}:</strong> 
-                        {{ 'Lunch' if period.get('is_lunch') else (class_name or 'Free') }}
+                        <strong>P{{ period.number }}:</strong>
+                        {% if period.get('is_lunch') %}
+                            Lunch
+                        {% else %}
+                            {{ class_info.name if class_info is mapping else (class_info or 'Free') }}
+                            {% if class_info is mapping and class_info.room %}<br><small>Room {{ class_info.room }}</small>{% endif %}
+                        {% endif %}
                         <br><small style="color: #666;">{{ period.start }} – {{ period.end }}</small>
                     </div>
                     {% endif %}

--- a/templates/student_detail.html
+++ b/templates/student_detail.html
@@ -400,9 +400,13 @@ Details{% endblock %} {% block content %}
       {% if student_schedule.classes %}
       <h4>Class Schedule:</h4>
       <div class="grid grid-2">
-        {% for period, class_name in student_schedule.classes.items() %}
+        {% for period, class_info in student_schedule.classes.items() %}
         <div style="padding: 5px">
-          <strong>Period {{ period }}:</strong> {{ class_name }}
+          {% if class_info is mapping %}
+            <strong>Period {{ period }}:</strong> {{ class_info.name }}{% if class_info.room %} (Room {{ class_info.room }}){% endif %}
+          {% else %}
+            <strong>Period {{ period }}:</strong> {{ class_info }}
+          {% endif %}
         </div>
         {% endfor %}
       </div>

--- a/templates/student_schedule_form.html
+++ b/templates/student_schedule_form.html
@@ -29,30 +29,27 @@
             </div>
         </div>
 
-        <div class="form-group">
-            <label for="room_number">Room Number</label>
-            <input type="text" id="room_number" name="room_number" 
-                value="{% if schedule and schedule.room_number %}{{ schedule.room_number }}{% endif %}"
-                placeholder="e.g., 205, Main Office, Library">
-            <small class="form-text">Room where student can be found (for facilitator)</small>
-        </div>
-    
-        
         <div style="margin: 2rem 0;">
             <h3>Class Schedule</h3>
             <p class="text-muted">Enter the student's classes for each period.</p>
         </div>
-        
-        <div class="grid grid-2">
-            {% for period in range(1, 9) %}
+        {% for period in range(1, 9) %}
+        <div class="grid grid-2" style="margin-bottom: 1rem;">
             <div class="form-group">
-                <label for="period_{{ period }}">Period {{ period }}</label>
-                <input type="text" id="period_{{ period }}" name="period_{{ period }}" 
-                       value="{% if schedule and schedule.classes %}{{ schedule.classes.get(period|string, '') }}{% endif %}"
+                <label for="period_{{ period }}">Period {{ period }} Class</label>
+                {% set class_info = schedule.classes.get(period|string) if schedule and schedule.classes else none %}
+                <input type="text" id="period_{{ period }}" name="period_{{ period }}"
+                       value="{% if class_info is mapping %}{{ class_info.name }}{% elif class_info %}{{ class_info }}{% endif %}"
                        placeholder="e.g., English 9, Algebra I">
             </div>
-            {% endfor %}
+            <div class="form-group">
+                <label for="room_{{ period }}">Room</label>
+                <input type="text" id="room_{{ period }}" name="room_{{ period }}"
+                       value="{% if class_info is mapping %}{{ class_info.room }}{% endif %}"
+                       placeholder="e.g., 205">
+            </div>
         </div>
+        {% endfor %}
         
         <div style="display: flex; gap: 1rem; margin-top: 2rem;">
             <button type="submit" class="btn btn-success">Save Schedule</button>


### PR DESCRIPTION
## Summary
- Allow entering a room number for each class period
- Persist room numbers alongside class names in student schedules
- Display per-period room information on student and school pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4db8c5bdc832097eb14fe010c7ebf