### PR TITLE
Add per-period room numbers to student schedules

### DIFF
--- a/routes/schools.py
+++ b/routes/schools.py
@@ -18,7 +18,7 @@ def school_detail(school_id):
     if not school:
         return "School not found", 404
     cursor = db.execute('''
-        SELECT s.*, ss.lunch_type, ss.classes
+        SELECT s.*, ss.lunch_type, ss.classes, ss.room_numbers
         FROM students s
         JOIN student_schedules ss ON s.id = ss.student_id
         WHERE ss.school_id = ?
@@ -30,7 +30,8 @@ def school_detail(school_id):
             'id': row['id'],
             'full_name': f"{row['first_name']} {row['last_name']}",
             'lunch_type': row['lunch_type'],
-            'classes': json.loads(row['classes']) if row['classes'] else {}
+            'classes': json.loads(row['classes']) if row['classes'] else {},
+            'room_numbers': json.loads(row['room_numbers']) if row['room_numbers'] else {}
         }
         students.append(student_data)
     schedule = None

--- a/routes/students.py
+++ b/routes/students.py
@@ -116,11 +116,16 @@ def student_schedule(student_id):
         schedule.school_id = request.form['school_id']
         schedule.lunch_type = request.form.get('lunch_type', 'A')
         classes = {}
+        room_numbers = {}
         for period in range(1,9):
             class_name = request.form.get(f'period_{period}', '').strip()
+            room_number = request.form.get(f'room_{period}', '').strip()
             if class_name:
                 classes[str(period)] = class_name
+            if room_number:
+                room_numbers[str(period)] = room_number
         schedule.classes = classes
+        schedule.room_numbers = room_numbers
         schedule.save(db)
         return redirect(url_for('students.student_detail', student_id=student_id))
     return render_template('student_schedule_form.html', student=student, schedule=schedule, schools=schools)

--- a/templates/school_detail.html
+++ b/templates/school_detail.html
@@ -139,13 +139,17 @@
                     {% set class_name = student.classes.get(period.number|string, '') %}
                     {% if class_name or period.get('is_lunch') %}
                     <div style="
-                        padding: 0.5rem; 
+                        padding: 0.5rem;
                         font-size: 0.9rem;
                         border-radius: 3px;
                         background: {% if period.get('is_lunch') %}#e8f5e8{% elif period.get('is_extension') and class_name %}#fff3cd{% elif class_name %}#e7f3ff{% else %}#f8f9fa{% endif %};
                     ">
-                        <strong>P{{ period.number }}:</strong> 
+                        <strong>P{{ period.number }}:</strong>
                         {{ 'Lunch' if period.get('is_lunch') else (class_name or 'Free') }}
+                        {% if not period.get('is_lunch') %}
+                            {% set room = student.room_numbers.get(period.number|string) %}
+                            {% if room %}<br><small style="color: #666;">Room {{ room }}</small>{% endif %}
+                        {% endif %}
                         <br><small style="color: #666;">{{ period.start }} – {{ period.end }}</small>
                     </div>
                     {% endif %}

--- a/templates/student_detail.html
+++ b/templates/student_detail.html
@@ -400,9 +400,11 @@ Details{% endblock %} {% block content %}
       {% if student_schedule.classes %}
       <h4>Class Schedule:</h4>
       <div class="grid grid-2">
-        {% for period, class_name in student_schedule.classes.items() %}
+        {% for period, class_name in student_schedule.classes|dictsort %}
         <div style="padding: 5px">
           <strong>Period {{ period }}:</strong> {{ class_name }}
+          {% set room = student_schedule.room_numbers.get(period) if student_schedule.room_numbers else '' %}
+          {% if room %}- Room {{ room }}{% endif %}
         </div>
         {% endfor %}
       </div>

--- a/templates/student_schedule_form.html
+++ b/templates/student_schedule_form.html
@@ -29,27 +29,24 @@
             </div>
         </div>
 
-        <div class="form-group">
-            <label for="room_number">Room Number</label>
-            <input type="text" id="room_number" name="room_number" 
-                value="{% if schedule and schedule.room_number %}{{ schedule.room_number }}{% endif %}"
-                placeholder="e.g., 205, Main Office, Library">
-            <small class="form-text">Room where student can be found (for facilitator)</small>
-        </div>
-    
-        
         <div style="margin: 2rem 0;">
             <h3>Class Schedule</h3>
             <p class="text-muted">Enter the student's classes for each period.</p>
         </div>
-        
+
         <div class="grid grid-2">
             {% for period in range(1, 9) %}
             <div class="form-group">
-                <label for="period_{{ period }}">Period {{ period }}</label>
-                <input type="text" id="period_{{ period }}" name="period_{{ period }}" 
+                <label for="period_{{ period }}">Period {{ period }} Class</label>
+                <input type="text" id="period_{{ period }}" name="period_{{ period }}"
                        value="{% if schedule and schedule.classes %}{{ schedule.classes.get(period|string, '') }}{% endif %}"
                        placeholder="e.g., English 9, Algebra I">
+            </div>
+            <div class="form-group">
+                <label for="room_{{ period }}">Period {{ period }} Room</label>
+                <input type="text" id="room_{{ period }}" name="room_{{ period }}"
+                       value="{% if schedule and schedule.room_numbers %}{{ schedule.room_numbers.get(period|string, '') }}{% endif %}"
+                       placeholder="e.g., 205, Main Office">
             </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
## Summary
- Capture room numbers for each class period in `StudentSchedule`
- Save and display period-specific room numbers across student and school views
- Add form fields for per-period room numbers when editing schedules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4db8c5bdc832097eb14fe010c7ebf